### PR TITLE
Fix overlap and change jquery cdn

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -135,7 +135,7 @@
     <!-- main end -->
     {% endif %}
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fitvids/1.1.0/jquery.fitvids.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
     <script src="{{ site.baseurl }}/js/tidal.js"></script>

--- a/css/tidal.scss
+++ b/css/tidal.scss
@@ -99,6 +99,7 @@ body {
 section {
     header {
         position: relative;
+        z-index: -1;
         &::before {
             content: "»";
             display: block;


### PR DESCRIPTION
![screen shot 2015-03-08 at 8 55 04 pm](https://cloud.githubusercontent.com/assets/349342/6546007/5ac36f30-c5dc-11e4-808a-324dc0a523ee.png)
1. the title overlap the link above, so that link can not clicked. add a `z-index` to the header
2. china blocked the google cdn, is that ok use the cloudflare for jquery?
