### PR TITLE
Bringing examples in line with Dirt default samples.

### DIFF
--- a/_patterns/pattern-groups.md
+++ b/_patterns/pattern-groups.md
@@ -6,19 +6,19 @@ layout: default
 Use Tidal's _square braces_ syntax to create a pattern grouping:
 
 ~~~haskell
-d1 $ sound "[bd sd] cp"
+d1 $ sound "[bd sn] cp"
 ~~~
 
 Square braces allow several events to be played inside of a single event.
 Practically, this means you can create denser sub-divisions of samples:
 
 ~~~haskell
-d1 $ sound "bd [sd sd]"
-d1 $ sound "bd [sd sd sd]"
-d1 $ sound "bd [sd sd sd sd]"
-d1 $ sound "[bd bd] [sd sd sd sd]"
-d1 $ sound "[bd bd bd] [sd sd]"
-d1 $ sound "[bd bd bd bd] [sd]"
+d1 $ sound "bd [sn sn]"
+d1 $ sound "bd [sn sn sn]"
+d1 $ sound "bd [sn sn sn sn]"
+d1 $ sound "[bd bd] [sn sn sn sn]"
+d1 $ sound "[bd bd bd] [sn sn]"
+d1 $ sound "[bd bd bd bd] [sn]"
 ~~~
 
 You can even nest groups inside groups to create very dense and complex

--- a/_patterns/repetition.md
+++ b/_patterns/repetition.md
@@ -40,10 +40,10 @@ d1 $ sound "bd/3" -- plays the bd samples only once each third cycle
 You can apply the `*` and `/` symbols on groups of patterns:
 
 ~~~haskell
-d1 $ sound "[bd sd]*2 cp"
-d1 $ sound "[bd sd] cp/2"
-d1 $ sound "[[bd sd] cp]*2" -- speeds up the entire pattern by 2
-d1 $ sound "[[bd sd] cp]/2" -- slows down the entire pattern by 2
+d1 $ sound "[bd sn]*2 cp"
+d1 $ sound "[bd sn] cp/2"
+d1 $ sound "[[bd sn] cp]*2" -- speeds up the entire pattern by 2
+d1 $ sound "[[bd sn] cp]/2" -- slows down the entire pattern by 2
 ~~~
 
 You can also use the symbols on nested groups to create more complex

--- a/_patterns/sequences.md
+++ b/_patterns/sequences.md
@@ -74,9 +74,9 @@ All of the samples inside of a pattern get squashed into a single cycle.
 The patterns below all loop over the same amount of time:
 
 ~~~haskell
-d1 $ sound "bd sd"
-d1 $ sound "bd sd hh cp mt arpy drum"
-d1 $ sound "bd sd hh cp mt arpy drum odx bd arpy bass2 feel future"
+d1 $ sound "bd sn"
+d1 $ sound "bd sn hh cp mt arpy drum"
+d1 $ sound "bd sn hh cp mt arpy drum odx bd arpy bass2 feel future"
 ~~~
 
 No matter how many samples you put in a pattern, they will always be


### PR DESCRIPTION
Dirt includes a directory of snare drums called `sn`. Whilst this
is occasionally used in examples, there are still references to a
snare directory called `sd` which will just lead to errors -
potentially confusing for new users.

This updates the _Creating Patterns_ pages to only refer to snare
drum directories included as standard in Dirt.
