### PR TITLE
Update bandf.md

### DIFF
--- a/_functions/synth_parameters/bandf.md
+++ b/_functions/synth_parameters/bandf.md
@@ -2,4 +2,4 @@
 title: bandf
 category: synth_parameters
 ---
-a pattern of numbers from 0 to 1. Sets the center frequency of the band-pass filter.
+a pattern of numbers. In SuperDirt, this is in Hz (try a range between 0 and 6000). In classic dirt, it is from 0 to 1. Sets the center frequency of the band-pass filter.


### PR DESCRIPTION
Update to reflect that bandpass frequencies are expressed in herz and not in 0.-1.0 scale in superdirt