### PR TITLE
Update and fix parameter reference pages

### DIFF
--- a/_functions/synth_parameters/bandq.md
+++ b/_functions/synth_parameters/bandq.md
@@ -2,4 +2,4 @@
 title: bandq
 category: synth_parameters
 ---
-a pattern of numbers from 0 to 1. Sets the q-factor of the band-pass filter.
+a pattern of numbers that set the q-factor of the band-pass filter.  Higher values (larger than 1) narrow the band-pass.

--- a/_functions/synth_parameters/begin.md
+++ b/_functions/synth_parameters/begin.md
@@ -4,7 +4,7 @@ category: synth_parameters
 ---
 a pattern of numbers from 0 to 1. Skips the beginning of each sample, e.g. `0.25` to cut off the first quarter from each sample.
 
-Using `begin "-1"` combined with `cut "-1"` means that when the sample cuts itself it will begin playback from where the previous one left off, so it will sound like one seamless sample. This allows you to apply a synth param across a long sample in a way similar to `chop`:
+In Classic Dirt, using `begin "-1"` combined with `cut "-1"` means that when the sample cuts itself it will begin playback from where the previous one left off, so it will sound like one seamless sample. This allows you to apply a synth param across a long sample in a way similar to `chop`:
 
 ~~~haskell
 cps 0.5

--- a/_functions/synth_parameters/delay.md
+++ b/_functions/synth_parameters/delay.md
@@ -2,4 +2,5 @@
 title: delay
 category: synth_parameters
 ---
-a pattern of numbers from 0 to 1. Sets the level of the delay signal.
+a pattern of numbers that set the initial level of the delay signal.  I.e. a value of one means the first echo will be as
+loud as the original sound.

--- a/_functions/synth_parameters/index.md
+++ b/_functions/synth_parameters/index.md
@@ -4,5 +4,5 @@ weight: -9
 ---
 
 In general, synth parameters specify patterns of sounds, and patterns
-of effects on those sounds. These are the synthesis parameters you can
-use with the default Dirt synth:
+of effects on those sounds. These are synthesis parameters you can
+use with the default SuperDirt synth or Classic Dirt:

--- a/_functions/synth_parameters/speed.md
+++ b/_functions/synth_parameters/speed.md
@@ -14,3 +14,5 @@ d1 $ s "arpy*4" # up "0 4 7 0"
 
 will play the "arpy" sample at the orginal speed, then up 4 semitones (a third), then up 7 semitones (a fifth), 
 then once more at the original speed.
+
+The behavior of `speed` can be changed by the [`unit` parameter](unit).

--- a/_functions/synth_parameters/speed.md
+++ b/_functions/synth_parameters/speed.md
@@ -2,4 +2,15 @@
 title: speed
 category: synth_parameters
 ---
-a pattern of numbers from 0 to 1, which changes the speed of sample playback, i.e. a cheap way of changing pitch
+A pattern of numbers which multiplies the speed of sample playback, where `1` means normal speed.  Can be used as a cheap way
+of changing pitch for samples.  Negative numbers will cause the sample to be played backwards.
+
+When using this method to alter sample pitch, there's a convenience parameter `up`, which uses units of semitones instead of
+multiplicative values.  For example,
+
+~~~haskell
+d1 $ s "arpy*4" # up "0 4 7 0"
+~~~
+
+will play the "arpy" sample at the orginal speed, then up 4 semitones (a third), then up 7 semitones (a fifth), 
+then once more at the original speed.

--- a/_functions/synth_parameters/speed.md
+++ b/_functions/synth_parameters/speed.md
@@ -15,4 +15,4 @@ d1 $ s "arpy*4" # up "0 4 7 0"
 will play the "arpy" sample at the orginal speed, then up 4 semitones (a third), then up 7 semitones (a fifth), 
 then once more at the original speed.
 
-The behavior of `speed` can be changed by the [`unit` parameter](unit).
+The behavior of `speed` can also be changed by the [`unit` parameter](unit).

--- a/_functions/synth_parameters/unit.md
+++ b/_functions/synth_parameters/unit.md
@@ -2,4 +2,13 @@
 title: unit
 category: synth_parameters
 ---
-only accepts a value of "c". Used in conjunction with `speed`, it time-stretches a sample to fit in a cycle.
+accepts values of "r" (default), "c", or "s", which controls how the `speed` parameter is interpreted.
+
+With `unit "r"`, `speed` multiplies the sample playback rate, so `1` is normal speed, `2` is double speed, `0.5` half
+speed, etc.
+
+With `unit "c"`, `speed` specifies the playback rate *relative to cycle length*.  So `unit "c" # speed "1"` will speed up or 
+slow down the sample to fit in one cycle, `unit "c" # speed "2"` will play the sample twice as fast (so that it fits in half
+a cycle), etc.  This can be useful for beat matching if your sample is a drum loop.
+
+With `unit "s"`, `speed` specifies the playback *length* in seconds.


### PR DESCRIPTION
I noticed some the reference pages for parameters were out of date (referencing classic Dirt as the default) or not quite right (some issues with `speed` and `unit`), so I've gone through the list and updated them where necessary.