### PR TITLE
Short paragraph about Vim support for TidalCycles

### DIFF
--- a/_getting_started/editors/vim.md
+++ b/_getting_started/editors/vim.md
@@ -3,7 +3,14 @@ title: Vim
 category: editors
 ---
 
-Installation instructions for the Vim editor have not yet been
-integrated into the documentation, but you can find details in [this
-forum
-thread](http://lurk.org/groups/tidal/messages/topic/5F3bHtJPs6NRmm0b2VyQ8Z/).
+Vim is another classic programmer's editor, with a more minimalistic approach
+than others, and famous for its peculiar and unique editing modes and hotkeys.
+
+Because Vim doesn't have native support for REPLs or interactive buffers, the
+[vim-tidal](https://github.com/munshkr/vim-tidal) plugin depends on
+[tmux](https://tmux.github.io/), a terminal multiplexer, to communicate between
+Vim and the Tidal interpreter.
+
+See
+[vim-tidal](https://github.com/munshkr/vim-tidal/blob/master/README.md#vim-tidal)
+for more information on how to install and use.


### PR DESCRIPTION
This updates the subsection on Editors/Vim with a short description and a link to the github repo with the complete installation and configuration instructions. Is this ok, or is it better to have all the instructions here too?