### PR TITLE
re-organized install doc to account for macos/cabal/stack quirks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .bundle/
 *~
 *.orig
+.jekyll-metadata

--- a/_getting_started/installation/index.md
+++ b/_getting_started/installation/index.md
@@ -4,35 +4,23 @@ layout: default
 weight: -9
 ---
 
-The following installation instructions work for Linux, MacOS and
-Windows.
+<style>
+  .marker { margin-bottom: 40px;}
+</style>
 
-There is an <a
-href="https://davidgranstrom.github.io/tidal-bootstrap/">automated
-script for MacOS X users</a>, along with a <a
-href="https://www.youtube.com/watch?v=dJTfGv2sT-w&t=2s">helpful
-walkthrough video</a>, as an alternative to the below.
+You can install TidalCycles on MacOS, Windows, and Linux. Locate the instructions
+below for your specific operating system.
 
-## If you have install issues
+* [MacOS](#macos)
+* [Windows](#windows)
+* [Linux](#linux)
 
-There appears to be an issue with Cabal that is affecting installation.  If you are unable to install TidalCycles with the directions below, please try these alternate installation instructions.
+<a id="macos">&nbsp;</a>
+<hr class="marker">
 
-From a terminal window, run this:
+## Mac OS 
 
-~~~~bash
-stack setup
-stack install tidal
-~~~~
-
-Once that's done, you'll also need to change a configuration setting
-in Atom. Find the package settings for TidalCycles (```preferences >
-tidalcycles > settings```). Change the ```'ghci path'``` option to this:
-
-```stack ghc -- --interactive -XOverloadedStrings```
-
-Restart Atom and it should be able to start TidalCycles.
-
-### Pre-requisites
+### 1. Prerequisites
 
 You first need to install the following three pieces of software,
 Haskell, Atom, and SuperCollider. You can download them from their
@@ -43,37 +31,33 @@ websites - click on each of the below:
 * [SuperCollider](http://supercollider.github.io/download) (version 3.7 or later)
 * You may also need to install [Git](https://git-scm.com/)
 
-For the curious: Haskell is the programming language that TidalCycles
-is written in, Atom is a programmers' editor that you will use to
-write TidalCycles patterns in, and SuperCollider will make all the
-noise, by hosting the SuperDirt synth that was made for TidalCycles.  Git is a
-program that lets your computer retrieve the source code for SuperDirt for use
-in SuperCollider.
+You will need the SuperCollider sc3-plugins for using many of the synths included in 
+SuperDirt. Most of the examples in the documentation will still work, so you could
+skip this step and return to it later. You can install the latest version from
+[github](https://github.com/supercollider/sc3-plugins) according to
+the instructions there.
 
-> If you are installing on Windows, make sure you follow Step 3 of the Haskell
-> installation [instructions](https://www.haskell.org/platform/#windows). Also on
-> Windows, when installing SuperCollider, you must also download the `sc3-plugins`
-> zip file. Run SuperCollider once in order to create user directories. Then open
-> the zip file and extract the `SC3plugins` directory to
-> `C:\Users\<username>\AppData\Local\SuperCollider\Extensions`. You may have to
-> manually create the `Extensions` directory. Restart SuperCollider so that it finds
-> the `SC3plugins` directory.
+### 2. Install the TidalCycles pattern engine
 
-> If you are installing on Linux or Mac you need the SuperCollider
-> sc3-plugins for using many of the synths included in SuperDirt. Most
-> of the examples in the documentation will still work, so you could
-> skip this step and return to it later. You can either install the
-> latest version from
-> [github](https://github.com/supercollider/sc3-plugins) according to
-> the instructions there, or if you are using Linux, you may find it
-> in your package manager. On Fedora the package is called
-> `supercollider-sc3-plugins`.
+>**NOTE** As of September 26 2017, There appears to be an issue with Cabal that is 
+>affecting installation on MacOS.  
+>If you are unable to install TidalCycles with the directions below, please try 
+>these alternate installation instructions. From a terminal window, run this:
 
-Once you have the above applications downloaded and installed, you
-will need to follow the following three steps to complete the
-installation:
+>~~~~bash
+>stack setup
+>stack install tidal
+>~~~~
 
-### 1. Install the TidalCycles pattern engine
+>Once that's done, you'll also need to change a configuration setting
+>in Atom. Find the package settings for TidalCycles (*preferences >
+>tidalcycles > settings*). Change the ```'ghci path'``` option to this:
+
+>```stack ghc -- --interactive```
+
+>Restart Atom and it should be able to start TidalCycles.
+
+#### Standard MacOS Instructions:
 
 Open a Terminal window and type in the following command, to install
 TidalCycles:
@@ -82,12 +66,11 @@ TidalCycles:
 cabal install tidal
 ~~~~
 
-> If you're unsure how to open a terminal window: in Windows it's
-> "command prompt" under accessories, in Mac OS it's "Terminal" under
-> Utilities, Linux varies according to distribution but generally find
-> "Terminal" in the menus).
+> If you're unsure how to open a terminal window, in Mac OS it's 
+> "Terminal" under Utilities.
 
-### 2. Install the SuperDirt synth
+
+### 3. Install the SuperDirt synth
 
 Start SuperCollider, and in the editor window paste in the following line of code:
 
@@ -119,11 +102,168 @@ Then you will need install git from
 [https://git-scm.com/downloads](https://git-scm.com/downloads), and
 return to SuperCollider to run `include("SuperDirt")` again.
 
-### 3. Install the TidalCycles Atom plugin
+
+### 4. Install the TidalCycles Atom plugin
 
 Start Atom, and install the TidalCycles plugin. You can find it via
 the menus under `edit > settings > install`, then typing “tidalcycles”
 into the search box. Once that's installed, restart atom.
+
+
+<a id="windows">&nbsp;</a>
+<hr class="marker">
+
+## Windows 
+
+### 1. Prerequisites
+
+You first need to install the following three pieces of software,
+Haskell, Atom, and SuperCollider. You can download them from their
+websites - click on each of the below:
+
+* [Haskell](https://www.haskell.org/platform/)
+* [Atom](https://atom.io/)
+* [SuperCollider](http://supercollider.github.io/download) (version 3.7 or later)
+* You may also need to install [Git](https://git-scm.com/)
+
+**Important:** Make sure you follow Step 2 of the Haskell 
+installation [instructions](https://www.haskell.org/platform/#windows). 
+
+**Important:** When installing SuperCollider, you must also download the `sc3-plugins`
+zip file. Run SuperCollider once in order to create user directories. Then open
+the zip file and extract the `SC3plugins` directory to
+`C:\Users\<username>\AppData\Local\SuperCollider\Extensions`. You may have to
+manually create the `Extensions` directory. Restart SuperCollider so that it finds
+the `SC3plugins` directory.
+
+### 2. Install the TidalCycles pattern engine
+
+Open a Terminal window and type in the following command, to install
+TidalCycles:
+
+~~~~bash
+cabal install tidal
+~~~~
+
+> If you're unsure how to open a terminal window: in Windows it's
+> "command prompt" under Accessories
+
+
+### 3. Install the SuperDirt synth
+
+Start SuperCollider, and in the editor window paste in the following line of code:
+
+~~~~c
+include("SuperDirt")
+~~~~
+
+Run the code by clicking on it, to make sure the cursor is on this
+line, then hold down shift and press enter.
+
+It will download SuperDirt and
+you will see it has completed when the Post Window displays:
+
+~~~~c
+... the class library may have to be recompiled.
+-> SuperDirt
+~~~~
+
+After it has completed, you will need to restart SuperCollider (or
+alternatively, recompile the class library via the "Language" menu).
+
+If you instead see a message like this:
+
+~~~~c
+  "ERROR: Quarks requires git to be installed"
+~~~~
+
+Then you will need install git from
+[https://git-scm.com/downloads](https://git-scm.com/downloads), and
+return to SuperCollider to run `include("SuperDirt")` again.
+
+### 4. Install the TidalCycles Atom plugin
+
+Start Atom, and install the TidalCycles plugin. You can find it via
+the menus under `edit > settings > install`, then typing “tidalcycles”
+into the search box. Once that's installed, restart atom.
+
+<a id="linux">&nbsp;</a>
+<hr class="marker">
+
+## Linux 
+
+### 1. Prerequisites
+
+You first need to install the following three pieces of software,
+Haskell, Atom, and SuperCollider. You can download them from their
+websites - click on each of the below:
+
+* [Haskell](https://www.haskell.org/platform/)
+* [Atom](https://atom.io/)
+* [SuperCollider](http://supercollider.github.io/download) (version 3.7 or later)
+* You may also need to install [Git](https://git-scm.com/)
+
+You need the SuperCollider
+sc3-plugins for using many of the synths included in SuperDirt. Most
+of the examples in the documentation will still work, so you could
+skip this step and return to it later. You can either install the
+latest version from
+[github](https://github.com/supercollider/sc3-plugins) according to
+the instructions there, or you may find it
+in your package manager. On Fedora the package is called
+`supercollider-sc3-plugins`.
+
+### 2. Install the TidalCycles pattern engine
+
+Open a Terminal window and type in the following command, to install
+TidalCycles:
+
+~~~~bash
+cabal install tidal
+~~~~
+
+> If you're unsure how to open a terminal window in Linux,
+> it varies according to distribution but generally find
+> "Terminal" in the menus).
+
+### 3. Install the SuperDirt synth
+
+Start SuperCollider, and in the editor window paste in the following line of code:
+
+~~~~c
+include("SuperDirt")
+~~~~
+
+Run the code by clicking on it, to make sure the cursor is on this
+line, then hold down shift and press enter.
+
+It will download SuperDirt and
+you will see it has completed when the Post Window displays:
+
+~~~~c
+... the class library may have to be recompiled.
+-> SuperDirt
+~~~~
+
+After it has completed, you will need to restart SuperCollider (or
+alternatively, recompile the class library via the "Language" menu).
+
+If you instead see a message like this:
+
+~~~~c
+  "ERROR: Quarks requires git to be installed"
+~~~~
+
+Then you will need install git from
+[https://git-scm.com/downloads](https://git-scm.com/downloads), and
+return to SuperCollider to run `include("SuperDirt")` again.
+
+### 4. Install the TidalCycles Atom plugin
+
+Start Atom, and install the TidalCycles plugin. You can find it via
+the menus under `edit > settings > install`, then typing “tidalcycles”
+into the search box. Once that's installed, restart atom.
+
 
 **That's it!** You're now ready to start TidalCycles and SuperDirt for
   the first time.

--- a/_getting_started/installation/index.md
+++ b/_getting_started/installation/index.md
@@ -57,6 +57,8 @@ the instructions there.
 
 >Restart Atom and it should be able to start TidalCycles.
 
+>**Skip ahead to MacOS Step #3 (Install the SuperDirt synth) if you used this method**
+
 #### Standard MacOS Instructions:
 
 Open a Terminal window and type in the following command, to install

--- a/_getting_started/installation/index.md
+++ b/_getting_started/installation/index.md
@@ -53,7 +53,7 @@ the instructions there.
 >in Atom. Find the package settings for TidalCycles (*preferences >
 >tidalcycles > settings*). Change the ```'ghci path'``` option to this:
 
->```stack ghc -- --interactive```
+>```stack ghc```
 
 >Restart Atom and it should be able to start TidalCycles.
 

--- a/_getting_started/running/index.md
+++ b/_getting_started/running/index.md
@@ -3,7 +3,8 @@ category: running
 weight: -9
 ---
 
-There are two steps to starting TidalCycles each time, first starting SuperDirt inside SuperCollider, and then starting TidalCycles inside Atom.
+There are two steps to starting TidalCycles each time, first starting SuperDirt 
+inside SuperCollider, and then starting TidalCycles inside Atom.
 
 To start SuperDirt, paste the following code into a SuperCollider
 window, click on the code, hold down shift and press enter.
@@ -11,6 +12,12 @@ window, click on the code, hold down shift and press enter.
 ~~~~c
 SuperDirt.start
 ~~~~
+
+>If you want SuperDirt to start automatically when you open SuperCollider, add the above
+>line to the SuperCollider startup file. You can edit the SuperCollider startup file
+>from within SuperCollider itself by choosing _File -> Open Startup File_ from the top menu.
+>If you wish to use a more comprehensive SuperDirt startup file with more options,
+>[refer to this example](https://github.com/musikinformatik/SuperDirt/blob/master/superdirt_startup.scd).
 
 To start TidalCycles in Atom, first create a new document and save it with a filename
 that ends in `.tidal`, e.g. `test.tidal`. Then open the Packages menu and select TidalCycles -> Boot TidalCycles.


### PR DESCRIPTION
Decided to re-org the install doc to account for the recent quirks with the MacOS install due to breaking cabal changes. 

The three OS installs have diverged enough over the past months with special instructions, so I broke them all out into their own complete install sections. There is a lot of repeated content, but IMO this is the easiest and most intuitive option for users to follow. 