### PR TITLE
Update shifting-time.md

### DIFF
--- a/_patterns/shifting-time.md
+++ b/_patterns/shifting-time.md
@@ -27,7 +27,6 @@ d1 $ every 3 (0.25 <~) $ sound "bd*2 cp*2 hh sn"
 ~~~haskell
 d1 $ every 3 (0.25 ~>) $ sound "bd*2 cp*2 hh sn"
 ~~~
-
 {: .render}
 
 You can shift patterns as little or as much as you'd like:


### PR DESCRIPTION
removed space before .render line (causing error when playing sound)

![image](https://user-images.githubusercontent.com/770012/48325636-95115980-e604-11e8-9b4d-e450880d3783.png)
